### PR TITLE
Tiny fix of the availabilities slider

### DIFF
--- a/app/views/shared/_availabilities_slider.html.haml
+++ b/app/views/shared/_availabilities_slider.html.haml
@@ -1,7 +1,7 @@
 - day_id = "day_" + day.id.to_s
 %span{ id: day_id }
   %h3
-    = t('availabilities.available_to')
+    = t('availabilities.available_from')
     %span.start_date
       = l day.start_date, format: :pretty_datetime
     = t('availabilities.available_to')


### PR DESCRIPTION
Previously it said "to $datetime to $datetime", 
should be "from $datetime to $datetime"